### PR TITLE
Fall back to gulp-vinyl-yazl if installation of gulp-vinyl-zip fails 

### DIFF
--- a/install_gulp-vinyl.js
+++ b/install_gulp-vinyl.js
@@ -1,0 +1,19 @@
+var squirrel = require("squirrel");
+
+squirrel.defaults.allowInstall = true;
+
+console.log("installing gulp-vinyl-zip");
+squirrel('gulp-vinyl-zip', function (err, zip) {
+    if (err || !zip) {
+        console.log('gulp-vinyl-zip installation failed, falling back to gulp-vinyl-yazl');
+        squirrel('gulp-vinyl-yazl', function (err, zip) {
+            if (err || !zip) {
+                console.log('gulp-vinyl-yazl installation failed');
+            } else {
+                console.log('gulp-vinyl-yazl was successfully installed!');
+            }
+        });
+    } else {
+        console.log('gulp-vinyl-zip was successfully installed!');
+    }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "gulp plugin for packaging Atom Shell applications",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "install": "node install_gulp-vinyl.js"
   },
   "repository": {
     "type": "git",
@@ -27,13 +28,17 @@
     "event-stream": "^3.1.7",
     "github-releases": "^0.2.0",
     "gulp-rename": "^1.2.0",
-    "gulp-vinyl-zip": "^0.0.6",
     "mkdirp": "^0.5.0",
     "plist": "^1.1.0",
     "progress": "^1.1.8",
     "rcedit": "^0.3.0",
     "temp": "^0.8.1",
-    "vinyl-fs": "^0.3.13"
+    "vinyl-fs": "^0.3.13",
+    "squirrel": "^1.0.0"
+  },
+  "pluginDependencies": {
+    "gulp-vinyl-zip": "^0.0.6",
+    "gulp-vinyl-yazl": "^0.1.2"
   },
   "devDependencies": {
     "mocha": "^2.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,11 @@
 
 var es = require('event-stream');
 var fs = require('vinyl-fs');
-var zfs = require('gulp-vinyl-zip');
+try {
+	var zfs = require('gulp-vinyl-zip');
+} catch (e) {
+	var zfs = require('gulp-vinyl-yazl');
+}
 var rename = require('gulp-rename');
 var download = require('./download');
 
@@ -23,7 +27,7 @@ function patchPackageJson(opts) {
 			f.contents = new Buffer(JSON.stringify(json), 'utf8');
 			that.emit('data', f);
 		}
-		
+
 		if (typeof opts.productVersion === 'function') {
 			opts.productVersion(function (err, version) {
 				if (err) { return that.emit('err'); }
@@ -37,7 +41,7 @@ function patchPackageJson(opts) {
 
 function moveApp(platform, opts) {
 	var appPath = platform.getAppPath(opts);
-	
+
 	return rename(function (path) {
 		path.dirname = appPath + (path.dirname === '.' ? '' : '/' + path.dirname);
 	});
@@ -59,6 +63,7 @@ function vanillaAtomshell(opts) {
 }
 
 function atomshell(opts) {
+	console.log("options:", opts);
 	if (!opts.version) {
 		throw new Error('Missing atom-shell option: version.');
 	}
@@ -66,11 +71,11 @@ function atomshell(opts) {
 	if (!opts.platform) {
 		throw new Error('Missing atom-shell option: platform.');
 	}
-	
+
 	if (!opts.productName) {
 		throw new Error('Missing atom-shell option: productName.');
 	}
-	
+
 	if (!opts.productVersion) {
 		throw new Error('Missing atom-shell option: productVersion.');
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,6 @@ function vanillaAtomshell(opts) {
 }
 
 function atomshell(opts) {
-	console.log("options:", opts);
 	if (!opts.version) {
 		throw new Error('Missing atom-shell option: version.');
 	}


### PR DESCRIPTION
Using [`squirrel`](https://www.npmjs.com/package/squirrel) within an install script to install [`gulp-vinyl-zip`](https://www.npmjs.com/package/gulp-vinyl-zip) and falls back to [`gulp-vinyl-yazl`](https://www.npmjs.com/package/gulp-vinyl-yazl) if the module fails to load. `gulp-vinyl-yazl` is javascript only so should never fail to install.

This is a quite ugly workaround until `gulp-vinyl-zip` is fixed.