### PR TITLE
Adapt to latest electron package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ var atomshell = require('gulp-atom-shell');
 
 gulp.task('default', function () {
 	return gulp.src('src/**')
-		.pipe(atomshell({ 
-				  version: '0.19.4',
+		.pipe(atomshell({
+				  version: '0.25.1',
 				  platform: 'darwin'
 		 }))
 		.pipe(atomshell.zfsdest('app.zip'));

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -16,7 +16,7 @@ exports.getAppPath = function(opts) {
 };
 
 function removeDefaultApp() {
-	var defaultAppPath = path.join('Atom.app', 'Contents', 'Resources', 'default_app');
+	var defaultAppPath = path.join('Electron.app', 'Contents', 'Resources', 'default_app');
 
 	return es.mapSync(function (f) {
 		if (!util.startsWith(f.relative, defaultAppPath)) {
@@ -30,7 +30,7 @@ function patchIcon(opts) {
 		return es.through();
 	}
 
-	var resourcesPath = path.join('Atom.app', 'Contents', 'Resources');
+	var resourcesPath = path.join('Electron.app', 'Contents', 'Resources');
 	var originalIconPath = path.join(resourcesPath, 'atom.icns');
 	var iconPath = path.join(resourcesPath, opts.productName + '.icns');
 	var pass = es.through();
@@ -49,7 +49,7 @@ function patchIcon(opts) {
 }
 
 function patchInfoPlist(opts) {
-	var infoPlistPath = path.join('Atom.app', 'Contents', 'Info.plist');
+	var infoPlistPath = path.join('Electron.app', 'Contents', 'Info.plist');
 
 	return es.map(function (f, cb) {
 		if (f.relative !== infoPlistPath) {
@@ -91,10 +91,10 @@ function renameApp(opts) {
 
 	return rename(function (path) {
 		// The app folder itself looks like a file
-		if (path.dirname === '.' && path.basename === 'Atom' && path.extname === '.app') {
+		if (path.dirname === '.' && path.basename === 'Electron' && path.extname === '.app') {
 			path.basename = opts.productAppName || opts.productName;
 		} else {
-			path.dirname = path.dirname.replace(/^Atom.app/, appName);
+			path.dirname = path.dirname.replace(/^Electron.app/, appName);
 		}
 	});
 }
@@ -109,4 +109,4 @@ exports.patch = function(opts) {
 		.pipe(renameApp(opts));
 
 	return es.duplex(pass, src);
-}
+};

--- a/src/download.js
+++ b/src/download.js
@@ -52,7 +52,7 @@ module.exports = function (opts, cb) {
 	}
 
 	var version = 'v' + opts.version;
-	var assetName = ['atom-shell', version, platform, arch].join('-') + '.zip';
+	var assetName = ['electron', version, platform, arch].join('-') + '.zip';
 
 	function download(assetPath, cb) {
 		github.getReleases({ tag_name: version }, function (err, releases) {

--- a/src/linux.js
+++ b/src/linux.js
@@ -21,7 +21,7 @@ function removeDefaultApp() {
 
 function renameApp(opts) {
 	return rename(function (path) {
-		if (path.dirname === '.' && path.basename === 'atom' && path.extname === '') {
+		if (path.dirname === '.' && path.basename === 'electron' && path.extname === '') {
 			path.basename = opts.productName;
 		}
 	});

--- a/src/win32.js
+++ b/src/win32.js
@@ -14,7 +14,7 @@ exports.getAppPath = function(opts) {
 
 function patchExecutable(opts) {
 	return es.map(function (f, cb) {
-		if (f.relative !== 'atom.exe' || process.platform !== 'win32') {
+		if (f.relative !== 'electron.exe' || process.platform !== 'win32') {
 			return cb(null, f);
 		}
 
@@ -68,7 +68,7 @@ function removeDefaultApp() {
 
 function renameApp(opts) {
 	return rename(function (path) {
-		if (path.dirname === '.' && path.basename === 'atom' && path.extname === '.exe') {
+		if (path.dirname === '.' && path.basename === 'electron' && path.extname === '.exe') {
 			path.basename = opts.productName;
 		}
 	});

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -8,7 +8,7 @@ describe('download', function () {
 	this.timeout(1000 * 60 * 5);
 
 	it('should work', function(cb) {
-		download({ version: '0.19.5', platform: 'darwin' }, function (err, assetPath) {
+		download({ version: '0.25.1', platform: 'darwin', token: process.env.ATOMSHELL_GITHUB_TOKEN }, function (err, assetPath) {
 			assert(!err);
 			assert(fs.existsSync(assetPath));
 			cb();
@@ -23,9 +23,9 @@ describe('atomshell', function () {
 		var didSeeInfoPList = false;
 
 		atomshell
-			.download({ version: '0.19.5', platform: 'darwin' })
+			.download({ version: '0.25.1', platform: 'darwin', token: process.env.ATOMSHELL_GITHUB_TOKEN })
 			.on('data', function (f) {
-				if (f.relative === path.join('Atom.app', 'Contents', 'Info.plist')) {
+				if (f.relative === path.join('Electron.app', 'Contents', 'Info.plist')) {
 					didSeeInfoPList = true;
 				}
 			})

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -21,21 +21,21 @@ describe('atomshell', function () {
 
 		assert.throws(function () {
 			atomshell({
-				version: '0.19.2',
+				version: '0.25.1',
 				productVersion: '0.0.1'
 			});
 		});
 
 		assert.throws(function () {
 			atomshell({
-				version: '0.19.2',
+				version: '0.25.1',
 				productName: 'TestApp'
 			});
 		});
 	});
 
 	describe('darwin', function () {
-		it('should copy app files and patch Atom', function(cb) {
+		it('should copy app files and patch Electron', function(cb) {
 			this.timeout(1000 * 60 * 5 /* 5 minutes */);
 
 			var files = {};
@@ -43,8 +43,9 @@ describe('atomshell', function () {
 
 			vfs.src('src/**/*')
 				.pipe(atomshell({
-					version: '0.19.2',
+					version: '0.25.1',
 					platform: 'darwin',
+					token: process.env.ATOMSHELL_GITHUB_TOKEN,
 					darwinIcon: path.join(__dirname, 'resources', 'myapp.icns')
 				}))
 				.on('data', function (f) {
@@ -69,7 +70,7 @@ describe('atomshell', function () {
 	});
 
 	describe('linux', function () {
-		it('should copy app files and patch Atom', function(cb) {
+		it('should copy app files and patch Electron', function(cb) {
 			this.timeout(1000 * 60 * 5 /* 5 minutes */);
 
 			var files = {};
@@ -77,8 +78,9 @@ describe('atomshell', function () {
 
 			vfs.src('src/**/*')
 				.pipe(atomshell({
-					version: '0.19.2',
-					platform: 'linux'
+					version: '0.25.1',
+					platform: 'linux',
+					token: process.env.ATOMSHELL_GITHUB_TOKEN
 				}))
 				.on('data', function (f) {
 					assert(!files[f.relative]);
@@ -105,7 +107,7 @@ describe('atomshell', function () {
 	});
 
 	describe('win32', function () {
-		it('should copy app files and patch Atom', function(cb) {
+		it('should copy app files and patch Electron', function(cb) {
 			this.timeout(1000 * 60 * 5 /* 5 minutes */);
 
 			var files = {};
@@ -113,8 +115,9 @@ describe('atomshell', function () {
 
 			vfs.src('src/**/*')
 				.pipe(atomshell({
-					version: '0.19.2',
-					platform: 'win32'
+					version: '0.25.1',
+					platform: 'win32',
+					token: process.env.ATOMSHELL_GITHUB_TOKEN
 				}))
 				.on('data', function (f) {
 					assert(!files[f.relative]);


### PR DESCRIPTION
In the latest electron release, executable name has been renamed to `Electron.app` from `Atom.app`