### PR TITLE
Weinand/more plist properties

### DIFF
--- a/src/darwin.js
+++ b/src/darwin.js
@@ -62,6 +62,8 @@ function patchInfoPlist(opts) {
 		f.contents.on('end', function () {
 			var infoPlist = plist.parse(contents.toString('utf8'));
 
+			infoPlist['CFBundleIdentifier'] = opts.darwinBundleIdentifier;
+			infoPlist['LSApplicationCategoryType'] = opts.darwinApplicationCategoryType;
 			infoPlist['CFBundleName'] = opts.productName;
 			infoPlist['CFBundleDisplayName'] = opts.productDisplayName || opts.productName;
 			infoPlist['CFBundleVersion'] = opts.productVersion;

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -67,6 +67,8 @@ function patchInfoPlist(opts) {
 			infoPlist['CFBundleName'] = opts.productName;
 			infoPlist['CFBundleDisplayName'] = opts.productDisplayName || opts.productName;
 			infoPlist['CFBundleVersion'] = opts.productVersion;
+			infoPlist['CFBundleShortVersionString'] = opts.productVersion;
+			infoPlist['NSHumanReadableCopyright'] = opts.copyright;
 			infoPlist['CFBundleIconFile'] = opts.productName + '.icns';
 
 			if (opts.darwinBundleDocumentTypes) {


### PR DESCRIPTION
I've made two important plist properties (CFBundleIdentifier, LSApplicationCategoryType) configurable and I've added two plist properties (CFBundleShortVersionString, NSHumanReadableCopyright) that reuse existing information.